### PR TITLE
net-misc/feather: fixed a typo in -DARCH (x86_64 to x86-64)

### DIFF
--- a/net-misc/feather/feather-9999.ebuild
+++ b/net-misc/feather/feather-9999.ebuild
@@ -42,7 +42,7 @@ BDEPEND="virtual/pkgconfig"
 
 src_configure() {
 	local mycmakeargs=(
-		-DARCH=x86_64
+		-DARCH=x86-64
 		-DBUILD_64=ON
 		-DBUILD_SHARED_LIBS=Off # Vendored Monero libs collision
 		-DBUILD_TAG="linux-x64"


### PR DESCRIPTION
Package-Manager: Portage-3.0.28, Repoman-3.0.3