### PR TITLE
net-misc/feather: add zbar dependency

### DIFF
--- a/net-misc/feather/feather-9999.ebuild
+++ b/net-misc/feather/feather-9999.ebuild
@@ -31,6 +31,7 @@ DEPEND="
 	>=dev-qt/qtwidgets-5.15
 	>=dev-qt/qtxml-5.15
 	media-gfx/qrencode:=
+	>=media-gfx/zbar-0.21
 	net-dns/unbound:=[threads]
 	net-libs/czmq:=
 "


### PR DESCRIPTION
I am surprised you even built this package without this dependency, perhaps it was only recently added, or it's pulled in by some USE flag for you, but it for me it won't compile without zbar. Version 0.21 specifically is what's referenced in the dockerfile in feather's git repository.