### PR TITLE
net-p2p/monero: Extend grace period when stopping openRC service

### DIFF
--- a/net-p2p/monero/files/monerod-0.16.0.3-r1.confd
+++ b/net-p2p/monero/files/monerod-0.16.0.3-r1.confd
@@ -4,3 +4,4 @@
 monerod_args="--config-file /etc/monero/monerod.conf --non-interactive"
 monerod_user=monero
 monerod_group=monero
+retry="SIGTERM/30"


### PR DESCRIPTION
By default, openRC declares a stopping service crashed after 5 seconds
of no progress. (man 8 start-stop-daemon)
Stopping monerod takes up to 30 seconds, when the blockchain
resides on an HDD.