### PR TITLE
added net-misc/feather-1.0.1 (but for real this time)

### DIFF
--- a/net-misc/feather/feather-1.0.1.ebuild
+++ b/net-misc/feather/feather-1.0.1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit cmake
 
@@ -18,19 +18,19 @@ MONERO_DIST_COMIT="6a2b96394d3c81a4ccf9be0daea02afe5f6f3683"
 
 DESCRIPTION="A free, open-source Monero wallet"
 HOMEPAGE="https://featherwallet.org"
-SRC_URI="https://github.com/feather-wallet/feather/archive/refs/tags/${PVR}.tar.gz -> ${PF}.tar.gz
-	https://github.com/feather-wallet/monero/archive/${MONERO_DIST_COMIT}.zip -> ${PF}-monero.zip
-	https://github.com/miniupnp/miniupnp/archive/${MINIUPNP_DIST_COMIT}.zip -> ${PF}-monero-miniupnp.zip
-	https://github.com/tevador/RandomX/archive/${RANDOMX_DIST_COMIT}.zip -> ${PF}-monero-randomx.zip
-	https://github.com/Tencent/rapidjson/archive/${RAPIDJSON_DIST_COMIT}.zip -> ${PF}-monero-rapidjson.zip
-	https://github.com/monero-project/supercop/archive/${SUPERCOP_DIST_COMIT}.zip -> ${PF}-monero-supercop.zip
-	https://github.com/trezor/trezor-common/archive/${TREZORCOMMON_DIST_COMIT}.zip -> ${PF}-monero-trezorcommon.zip
-	https://github.com/monero-project/unbound/archive/${UNBOUND_DIST_COMIT}.zip -> ${PF}-monero-unbound.zip
+SRC_URI="https://github.com/feather-wallet/feather/archive/refs/tags/${PV}.tar.gz -> ${PF}.tar.gz
+	https://github.com/feather-wallet/monero/archive/${MONERO_DIST_COMIT}.tar.gz -> ${PF}-monero.tar.gz
+	https://github.com/miniupnp/miniupnp/archive/${MINIUPNP_DIST_COMIT}.tar.gz -> ${PF}-monero-miniupnp.tar.gz
+	https://github.com/tevador/RandomX/archive/${RANDOMX_DIST_COMIT}.tar.gz -> ${PF}-monero-randomx.tar.gz
+	https://github.com/Tencent/rapidjson/archive/${RAPIDJSON_DIST_COMIT}.tar.gz -> ${PF}-monero-rapidjson.tar.gz
+	https://github.com/monero-project/supercop/archive/${SUPERCOP_DIST_COMIT}.tar.gz -> ${PF}-monero-supercop.tar.gz
+	https://github.com/trezor/trezor-common/archive/${TREZORCOMMON_DIST_COMIT}.tar.gz -> ${PF}-monero-trezorcommon.tar.gz
+	https://github.com/monero-project/unbound/archive/${UNBOUND_DIST_COMIT}.tar.gz -> ${PF}-monero-unbound.tar.gz
 "
 
 # Feather is released under the terms of the BSD license, but it vendors
-# code from Monero and Tor too.
-LICENSE="BSD MIT"
+# code from Monero and Tor too. trezor-common is under LGPLv3.
+LICENSE="BSD LGPL-3.0 MIT"
 SLOT="0"
 KEYWORDS="~amd64"
 IUSE="qrcode xmrig"
@@ -62,13 +62,13 @@ RDEPEND="
 BDEPEND="virtual/pkgconfig"
 
 src_prepare() {
-	mv -T ${WORKDIR}/monero-${MONERO_DIST_COMIT} ${WORKDIR}/${PF}/monero
-	mv -T ${WORKDIR}/miniupnp-${MINIUPNP_DIST_COMIT} ${WORKDIR}/${PF}/monero/external/miniupnp
-	mv -T ${WORKDIR}/RandomX-${RANDOMX_DIST_COMIT} ${WORKDIR}/${PF}/monero/external/randomx
-	mv -T ${WORKDIR}/rapidjson-${RAPIDJSON_DIST_COMIT} ${WORKDIR}/${PF}/monero/external/rapidjson
-	mv -T ${WORKDIR}/supercop-${SUPERCOP_DIST_COMIT} ${WORKDIR}/${PF}/monero/external/supercop
-	mv -T ${WORKDIR}/trezor-common-${TREZORCOMMON_DIST_COMIT} ${WORKDIR}/${PF}/monero/external/trezor-common
-	mv -T ${WORKDIR}/unbound-${UNBOUND_DIST_COMIT} ${WORKDIR}/${PF}/monero/external/unbound
+	mv -T "${WORKDIR}"/monero-${MONERO_DIST_COMIT} "${WORKDIR}"/${PF}/monero
+	mv -T "${WORKDIR}"/miniupnp-${MINIUPNP_DIST_COMIT} "${WORKDIR}"/${PF}/monero/external/miniupnp
+	mv -T "${WORKDIR}"/RandomX-${RANDOMX_DIST_COMIT} "${WORKDIR}"/${PF}/monero/external/randomx
+	mv -T "${WORKDIR}"/rapidjson-${RAPIDJSON_DIST_COMIT} "${WORKDIR}"/${PF}/monero/external/rapidjson
+	mv -T "${WORKDIR}"/supercop-${SUPERCOP_DIST_COMIT} "${WORKDIR}"/${PF}/monero/external/supercop
+	mv -T "${WORKDIR}"/trezor-common-${TREZORCOMMON_DIST_COMIT} "${WORKDIR}"/${PF}/monero/external/trezor-common
+	mv -T "${WORKDIR}"/unbound-${UNBOUND_DIST_COMIT} "${WORKDIR}"/${PF}/monero/external/unbound
 	cmake_src_prepare
 }
 

--- a/net-misc/feather/feather-1.0.1.ebuild
+++ b/net-misc/feather/feather-1.0.1.ebuild
@@ -1,0 +1,107 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake
+
+#Note: this is like a tree, with dependencies-of-dependencies
+#You need to update all of these recursively every version bump.
+#But at least they are distfiles if github goes down. ¯\_(ツ)_/¯
+MONERO_DIST_COMIT="6a2b96394d3c81a4ccf9be0daea02afe5f6f3683"
+	MINIUPNP_DIST_COMIT="544e6fcc73c5ad9af48a8985c94f0f1d742ef2e0"
+	RANDOMX_DIST_COMIT="fe4324e8c0c035fec3affd6e4c49241c2e5b9955"
+	RAPIDJSON_DIST_COMIT="129d19ba7f496df5e33658527a7158c79b99c21c"
+	SUPERCOP_DIST_COMIT="633500ad8c8759995049ccd022107d1fa8a1bbc9"
+	TREZORCOMMON_DIST_COMIT="bff7fdfe436c727982cc553bdfb29a9021b423b0"
+	UNBOUND_DIST_COMIT="0f6c0579d66b65f86066e30e7876105ba2775ef4"
+
+DESCRIPTION="A free, open-source Monero wallet"
+HOMEPAGE="https://featherwallet.org"
+SRC_URI="https://github.com/feather-wallet/feather/archive/refs/tags/${PVR}.tar.gz -> ${PF}.tar.gz
+	https://github.com/feather-wallet/monero/archive/${MONERO_DIST_COMIT}.zip -> ${PF}-monero.zip
+	https://github.com/miniupnp/miniupnp/archive/${MINIUPNP_DIST_COMIT}.zip -> ${PF}-monero-miniupnp.zip
+	https://github.com/tevador/RandomX/archive/${RANDOMX_DIST_COMIT}.zip -> ${PF}-monero-randomx.zip
+	https://github.com/Tencent/rapidjson/archive/${RAPIDJSON_DIST_COMIT}.zip -> ${PF}-monero-rapidjson.zip
+	https://github.com/monero-project/supercop/archive/${SUPERCOP_DIST_COMIT}.zip -> ${PF}-monero-supercop.zip
+	https://github.com/trezor/trezor-common/archive/${TREZORCOMMON_DIST_COMIT}.zip -> ${PF}-monero-trezorcommon.zip
+	https://github.com/monero-project/unbound/archive/${UNBOUND_DIST_COMIT}.zip -> ${PF}-monero-unbound.zip
+"
+
+# Feather is released under the terms of the BSD license, but it vendors
+# code from Monero and Tor too.
+LICENSE="BSD MIT"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="qrcode xmrig"
+
+DEPEND="
+	dev-libs/boost:=[nls]
+	dev-libs/libgcrypt:=
+	dev-libs/libsodium:=
+	dev-libs/libzip:=
+	dev-libs/monero-seed
+	dev-libs/openssl:=
+	>=dev-qt/qtcore-5.15
+	>=dev-qt/qtgui-5.15
+	>=dev-qt/qtnetwork-5.15
+	>=dev-qt/qtsvg-5.15
+	>=dev-qt/qtwebsockets-5.15
+	>=dev-qt/qtwidgets-5.15
+	>=dev-qt/qtxml-5.15
+	media-gfx/qrencode:=
+	net-dns/unbound:=[threads]
+	net-libs/czmq:=
+	media-gfx/zbar:=[v4l]
+"
+RDEPEND="
+	${DEPEND}
+	net-vpn/tor
+	xmrig? ( net-misc/xmrig )
+"
+BDEPEND="virtual/pkgconfig"
+
+src_prepare() {
+	mv -T ${WORKDIR}/monero-${MONERO_DIST_COMIT} ${WORKDIR}/${PF}/monero
+	mv -T ${WORKDIR}/miniupnp-${MINIUPNP_DIST_COMIT} ${WORKDIR}/${PF}/monero/external/miniupnp
+	mv -T ${WORKDIR}/RandomX-${RANDOMX_DIST_COMIT} ${WORKDIR}/${PF}/monero/external/randomx
+	mv -T ${WORKDIR}/rapidjson-${RAPIDJSON_DIST_COMIT} ${WORKDIR}/${PF}/monero/external/rapidjson
+	mv -T ${WORKDIR}/supercop-${SUPERCOP_DIST_COMIT} ${WORKDIR}/${PF}/monero/external/supercop
+	mv -T ${WORKDIR}/trezor-common-${TREZORCOMMON_DIST_COMIT} ${WORKDIR}/${PF}/monero/external/trezor-common
+	mv -T ${WORKDIR}/unbound-${UNBOUND_DIST_COMIT} ${WORKDIR}/${PF}/monero/external/unbound
+	cmake_src_prepare
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DARCH=x86-64
+		-DBUILD_64=ON
+		-DBUILD_SHARED_LIBS=Off # Vendored Monero libs collision
+		-DBUILD_TAG="linux-x64"
+		-DBUILD_TESTS=OFF
+		-DDONATE_BEG=OFF
+		-DINSTALL_VENDORED_LIBUNBOUND=OFF
+		-DMANUAL_SUBMODULES=1
+		-DSTATIC=OFF
+		-DUSE_DEVICE_TREZOR=OFF
+		-DXMRIG=$(usex xmrig)
+		-DWITH_SCANNER=$(usex qrcode)
+		-DCMAKE_DISABLE_FIND_PACKAGE_Git=ON #disables fetching/checking git submodules
+		-DVERSION_IS_RELEASE=true
+	)
+
+	cmake_src_configure
+}
+
+src_compile() {
+	cmake_build feather
+}
+
+src_install() {
+	dobin "${BUILD_DIR}/bin/feather"
+}
+
+pkg_postinst() {
+	einfo "Ensure that Tor is running with 'rc-service tor start' before"
+	einfo "using Feather."
+}


### PR DESCRIPTION
This is my first real ebuild, so you might want to take another look at this, as I don't know all the ebuild features and stuff.

I thought it would be better to use archives instead of doing `inherit git-r3` and expecting it to do the sub-modules. Firstly, because I read git-r3 is just for "live ebuilds", and secondly because it provides some reliability as distfiles are cached by gentoo infrastructure (If these ever get added to the main gentoo tree). The disadvantage is that you have to update the comits of each dependency that these feather devs re-distrubute with their package (monero), and the dependencies-of-dependencies (miniupnp, etc.) and so on.

I don't know if you want me to include the whole `repoman manifest` thing in the commit. I don't know how to do that in this repository. I just worked on this from my own `/var/db/repo/ethark`, and when I finished I copied the ebuild to ~/gentoo-monero where I made the commit.

Lastly, I'm just going to point out that it doesn't build without `media-gfx/zbar`, even if you use -DWITH_SCANNER. Look at their CMakeLists.txt, it looks like DWITH_SCANNER is just for v4l or something, dunno. Should we tell them or just patch that ourselves? Actually, screw it, we should just drop the `qrcode` useflag and make a `media-gfx/zbar` mandatory dependency.