### PR TITLE
net-misc/feather: changed feather-9999 git repo

### DIFF
--- a/net-misc/feather/feather-9999.ebuild
+++ b/net-misc/feather/feather-9999.ebuild
@@ -8,7 +8,7 @@ inherit cmake git-r3
 DESCRIPTION="A free, open-source Monero wallet"
 HOMEPAGE="https://featherwallet.org"
 SRC_URI=""
-EGIT_REPO_URI="https://git.featherwallet.org/feather/feather.git"
+EGIT_REPO_URI="https://github.com/feather-wallet/feather.git"
 
 # Feather is released under the terms of the BSD license, but it vendors
 # code from Monero and Tor too.


### PR DESCRIPTION
Package-Manager: Portage-3.0.30, Repoman-3.0.3

Feather changed its git repo, so I updated the 9999 version accordingly.